### PR TITLE
Update GIS section E text

### DIFF
--- a/dialogs/GIS-sectionE/language-generation/en-us/GIS-sectionE.en-us.lg
+++ b/dialogs/GIS-sectionE/language-generation/en-us/GIS-sectionE.en-us.lg
@@ -1,14 +1,14 @@
 [import](common.lg)
 
 # ChoiceInput_Prompt_mRYyQq_text()
-- Did your income (excluding Old Age Security and Guaranteed Income Supplement) change in 2020?
+- In 2020, did you have other source of income other than the ones listed here?
 # ChoiceInput_Prompt_mRYyQq()
 [Activity
     Text = ${ChoiceInput_Prompt_mRYyQq_text()}
 ]
 
 # ChoiceInput_InvalidPrompt_mRYyQq_text()
-- Hmm, I'm not sure what you meant. Did your income change in 2020?
+- Hmm, I'm not sure what you meant. In 2020, did you have other source of income other than the ones listed here?
 # ChoiceInput_InvalidPrompt_mRYyQq()
 [Activity
     Text = ${ChoiceInput_InvalidPrompt_mRYyQq_text()}


### PR DESCRIPTION
Update section E prompt and error handling text. This is to match the Miro board. There will be a note left about this section in design documentation. Unsure if text is the best for this section, but we're running out of time and it's what has been approved. 