### PR TITLE
removed airtable call to getGISData

### DIFF
--- a/dialogs/GIS-previousYearIncomeStatement/GIS-previousYearIncomeStatement.dialog
+++ b/dialogs/GIS-previousYearIncomeStatement/GIS-previousYearIncomeStatement.dialog
@@ -17,14 +17,6 @@
       },
       "actions": [
         {
-          "$kind": "Microsoft.BeginDialog",
-          "$designer": {
-            "id": "AOxl3g"
-          },
-          "activityProcessed": true,
-          "dialog": "getGISData"
-        },
-        {
           "$kind": "Microsoft.SetProperties",
           "$designer": {
             "id": "0OiFir"


### PR DESCRIPTION
This data is locally set as 0 to start instead of being pulled from a database.